### PR TITLE
fix dark mode to 1.3.2 behavior

### DIFF
--- a/Tweak/AXNAppCell.m
+++ b/Tweak/AXNAppCell.m
@@ -310,6 +310,26 @@
     [self setNeedsLayout];
 }
 
+-(void)setDarkMode:(BOOL)darkMode {
+    if (_darkMode == darkMode) return;
+
+    CGRect frame = self.blurView.frame;
+    if(darkMode) {
+      id materialView = objc_getClass("MTMaterialView");
+      if([materialView respondsToSelector:@selector(materialViewWithRecipe:options:)]) {
+        self.blurView = [materialView materialViewWithRecipe:MTMaterialRecipeNotifications options:MTMaterialOptionsBlur];
+      } else {
+        self.blurView = [materialView materialViewWithRecipe:MTMaterialRecipeNotifications configuration:1];
+      }
+      self.blurView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.45];
+    } else self.blurView = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleLight]];
+    self.blurView.frame = frame;
+    self.badgeLabel.textColor = darkMode ? [UIColor whiteColor] : [UIColor blackColor];
+    self.badgeLabel.alpha = 0.4f;
+
+    [self setNeedsDisplay];
+}
+
 -(void)setSelected:(BOOL)selected {
     [super setSelected:selected];
     if(self.selectionStyle == 2) return;


### PR DESCRIPTION
I noticed that the dark mode toggle in 1.3.3 doesn't do anything. Observations:

1.3.2 - 
Dark Mode preference enabled and dark system: dark
Dark Mode preference enabled and light system: light
Dark Mode preference disabled and dark system: light
Dark Mode preference disabled and light system: light

1.3.3 - 
Dark Mode preference enabled and dark system: light
Dark Mode preference enabled and light system: light
Dark Mode preference disabled and dark system: light
Dark Mode preference disabled and light system: light

Axon stays light regardless of tweak preferences.

I think this is due to #84, this PR simply adds back the removed code back which restores the prior behavior. After adding setDarkMode back:

Proposed PR - 
Dark Mode preference enabled and dark system: dark
Dark Mode preference enabled and light system: light
Dark Mode preference disabled and dark system: light
Dark Mode preference disabled and light system: light

This should fix #87, tested on iOS 14.1. 